### PR TITLE
Remove deprecation warnings about evaluating as bare variable

### DIFF
--- a/T-Sec.LinuxOS.Compliance/tasks/hardening_linux(01)basic-hardening.yml
+++ b/T-Sec.LinuxOS.Compliance/tasks/hardening_linux(01)basic-hardening.yml
@@ -70,14 +70,14 @@
     name: '{{ item }}'
     state: absent
   with_items: '{{ servers }}'
-  when: uninstall_servers
+  when: uninstall_servers|bool
 
 - name: req-003.2 uninstall clients
   package:
     name: '{{ item }}'
     state: absent
   with_items: '{{ clients }}'
-  when: uninstall_clients
+  when: uninstall_clients|bool
 
 # Req 4:	Unused filesystems must be disabled.
 
@@ -85,7 +85,7 @@
   package:
     name: '{{ modprobe_package }}'
     state: present
-  when: disable_filesystems
+  when: disable_filesystems|bool
 
 - name: req-004.2 disable unused filesystems
   template:
@@ -94,7 +94,7 @@
     owner: root
     group: root
     mode: 0640
-  when: disable_filesystems
+  when: disable_filesystems|bool
 
 - name: req-004.3 check loaded kernel modules
   modprobe:
@@ -102,7 +102,7 @@
     state: absent
   with_items:
     - "{{ filesystems }}"
-  when: disable_filesystems
+  when: disable_filesystems|bool
 
 # Req 5:	Dedicated partitions must be used for growing content that can
 # influence the availability of the system.
@@ -116,7 +116,7 @@
   package:
     name: 'autofs'
     state: absent
-  when: uninstall_autofs
+  when: uninstall_autofs|bool
 
 # Req 8: The use of at/cron must be restricted to authorized users.
 
@@ -127,7 +127,7 @@
   with_items:
     - "/etc/cron.deny"
     - "/etc/at.deny"
-  when: config_cron
+  when: config_cron|bool
 
 - name: req-008.2 generate cron & at allow files
   copy:
@@ -140,7 +140,7 @@
   with_items:
     - "/etc/cron.allow"
     - "/etc/at.allow"
-  when: config_cron
+  when: config_cron|bool
 
 # Req 9: Sticky bit must be set on all world-writable directories.
 
@@ -148,7 +148,7 @@
   shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type d -perm -0002 \! -perm -1000 2>/dev/null
   register: check_directories
   changed_when: false
-  when: config_worldwritable_directories
+  when: config_worldwritable_directories|bool
 
 - name: req-009.2 set sticky bit for world-writable directories
   file:
@@ -181,7 +181,7 @@
     state: present
     regexp: '^ENCRYPT_METHOD*'
     line: 'ENCRYPT_METHOD SHA512'
-  when: config_sha512
+  when: config_sha512|bool
 
 - name: req-011.2 set max rounds for sha-512
   lineinfile:
@@ -189,7 +189,7 @@
     state: present
     regexp: '^SHA_CRYPT_MAX_ROUNDS*'
     line: 'SHA_CRYPT_MAX_ROUNDS {{ sha512_rounds_max }}'
-  when: config_sha512
+  when: config_sha512|bool
 
 - name: req-011.3 set min rounds for sha-512
   lineinfile:
@@ -198,7 +198,7 @@
     regexp: '^SHA_CRYPT_MIN_ROUNDS*'
     insertafter: '^ENCRYPT_METHOD SHA512'
     line: 'SHA_CRYPT_MIN_ROUNDS {{ sha512_rounds_min }}'
-  when: config_sha512
+  when: config_sha512|bool
 
 # Req 12: The default user umask must be 027 or more restrictive.
 
@@ -208,7 +208,7 @@
     line: 'UMASK {{ umask }}'
     regexp: '^UMASK'
     state: present
-  when: config_umask
+  when: config_umask|bool
 
 # Req 13:	Not needed SUID and SGID bits must be removed from executables.
 
@@ -216,12 +216,12 @@
   shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type f \( -perm -4000 -o -perm -2000 \) -print 2>/dev/null
   register: sbit_binaries
   changed_when: false
-  when: config_suid_sgid
+  when: config_suid_sgid|bool
 
 - name: req-013.2 combine found files with default whitelist
   set_fact:
     suid: '{{ sbit_binaries.stdout_lines | difference(suid_sgid_whitelist) }}'
-  when: config_suid_sgid
+  when: config_suid_sgid|bool
 
 - name: req-013.3 remove suid/sgid bit from all binaries except whitelists
   file:
@@ -231,7 +231,7 @@
     follow: 'yes'
   with_items:
     - "{{ suid }}"
-  when: config_suid_sgid
+  when: config_suid_sgid|bool
 
 # Req 14:	Core dumps must be disabled.
 
@@ -242,7 +242,7 @@
     owner: root
     group: root
     mode: 0755
-  when: config_coredumps
+  when: config_coredumps|bool
 
 - name: req-014.2 create file limits.conf
   template:
@@ -251,7 +251,7 @@
     owner: root
     group: root
     mode: 0440
-  when: config_coredumps
+  when: config_coredumps|bool
 
 - name: reg-014.3 check sysctl-settings for coredumps
   sysctl:
@@ -261,7 +261,7 @@
     state: present
     reload: yes
   with_dict: '{{ coredumps }}'
-  when: config_coredumps
+  when: config_coredumps|bool
 
 # Req 15:	Protection against buffer overflows must be enabled.
 
@@ -270,7 +270,7 @@
   register: check_nx
   failed_when: check_nx.stdout != "active"
   changed_when: false
-  when: config_buffer_overflow_protection
+  when: config_buffer_overflow_protection|bool
 
 - name: reg-015.2 check sysctl-settings for buffer overflow protection
   sysctl:
@@ -280,7 +280,7 @@
     state: present
     reload: yes
   with_dict: '{{ buffer_overflow_protection }}'
-  when: config_buffer_overflow_protection
+  when: config_buffer_overflow_protection|bool
 
 # Req 16:	Prelink must not be used.
 
@@ -300,7 +300,7 @@
     state: present
     reload: yes
   with_dict: '{{ network_config_ipv4 }}'
-  when: config_network_ipv4
+  when: config_network_ipv4|bool
 
 # Req 18:	IPv6 protocol stack must be securely configured.
 
@@ -343,7 +343,7 @@
   shell: awk -F':' '($1!="root" && $1!="sync" && $1!="shutdown" && $1!="halt" && $3<{{ uid_max }} && $7=="/bin/bash") {print $1}' /etc/passwd
   register: check_sys_accounts
   changed_when: false
-  when: config_nologin_sys_accounts
+  when: config_nologin_sys_accounts|bool
 
 - name: req-022.2 disable login for system accounts
   shell: /usr/sbin/usermod -s {{ nologin_path }} {{ item }}
@@ -357,7 +357,7 @@
   shell: awk -F":" '($2 == "" && $2 != "!" && $2 !="*") {print $1}' /etc/shadow
   register: user_without_pw
   changed_when: false
-  when: config_user_without_pw
+  when: config_user_without_pw|bool
 
 - name: req-023.2 lock accounts without password
   shell: passwd -l "{{ item }}"

--- a/T-Sec.LinuxOS.Compliance/tasks/hardening_linux(02)logging.yml
+++ b/T-Sec.LinuxOS.Compliance/tasks/hardening_linux(02)logging.yml
@@ -10,7 +10,7 @@
 - name: req-030.1 enable logging before auditd starts
   lineinfile:
     path: '/etc/default/grub'
-    regexp: ^GRUB_CMDLINE_LINUX=(.*)"
+    regexp: "^GRUB_CMDLINE_LINUX=(.*)"
     line: GRUB_CMDLINE_LINUX="audit=1"
     state: present
   notify: update grub

--- a/T-Sec.LinuxOS.Compliance/tasks/hardening_linux(02)logging.yml
+++ b/T-Sec.LinuxOS.Compliance/tasks/hardening_linux(02)logging.yml
@@ -14,7 +14,7 @@
     line: GRUB_CMDLINE_LINUX="audit=1"
     state: present
   notify: update grub
-  when: config_grub_logging
+  when: config_grub_logging|bool
 
 # Req 31:	Log rotation for logfiles must be configured.
 
@@ -25,7 +25,7 @@
     owner: root
     group: root
     mode: 0644
-  when: config_log_rotate
+  when: config_log_rotate|bool
 
 # Req 32:	System time must be synchronized against a reference time source.
 
@@ -33,7 +33,7 @@
   package:
     name: "{{ ntp_software }}"
     state: present
-  when: config_ntp
+  when: config_ntp|bool
 
 - name: req-032.2 set time zone
   command: timedatectl set-timezone {{ use_timezone }}
@@ -48,7 +48,7 @@
     group: root
     mode: 0644
   notify: restart ntp
-  when: config_ntp
+  when: config_ntp|bool
 
 - name: req-032.4 change init.d/ntp file
   lineinfile:
@@ -70,7 +70,7 @@
   package:
     name: '{{ audit_software }}'
     state: present
-  when: config_auditd
+  when: config_auditd|bool
 
 - name: req-033.3 check max size for log rotate in auditd.conf
   lineinfile:
@@ -112,7 +112,7 @@
     mode: 0640
     backup: yes
   notify: restart auditd
-  when: config_auditd
+  when: config_auditd|bool
 
 - name: req-035.2 search for privileged commands
   shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type f \( -perm -4000 -o -perm -2000 \) -print 2>/dev/null
@@ -147,7 +147,7 @@
   package:
     name: '{{ syslog_type }}'
     state: present
-  when: config_syslog
+  when: config_syslog|bool
 
 # Req 40:	If RSyslog is used, the default permission of 640 or more restrictive
 # for logfiles must be configured.

--- a/T-Sec.LinuxOS.Compliance/tasks/hardening_linux(03)pam.yml
+++ b/T-Sec.LinuxOS.Compliance/tasks/hardening_linux(03)pam.yml
@@ -48,7 +48,7 @@
   package:
     name: '{{ os_pam_cracklib }}'
     state: absent
-  when: config_pam_password_rules
+  when: config_pam_password_rules|bool
 
 - name: req-045.2 install 'libpam-pwquality' (Ubuntu)
   package:
@@ -66,7 +66,7 @@
       - retry=3
     state: args_present
   with_items: "{{ os_pamd_config_files }}"
-  when: config_pam_password_rules
+  when: config_pam_password_rules|bool
 
 - name: req-045.4 configure password rules
   template:
@@ -75,7 +75,7 @@
     owner: root
     group: root
     mode: 0644
-  when: config_pam_password_rules
+  when: config_pam_password_rules|bool
 
 # Req 46:	If PAM is used, a protection against brute force and dictionary attacks
 # that hinder pass-word guessing must be configured in PAM.

--- a/T-Sec.LinuxOS.Compliance/tasks/hardening_linux(04)iptables.yml
+++ b/T-Sec.LinuxOS.Compliance/tasks/hardening_linux(04)iptables.yml
@@ -74,7 +74,7 @@
     ctstate: NEW
     jump: ACCEPT
   with_items: "{{ tcp_services }}"
-  when: config_iptables_rules_tcp
+  when: config_iptables_rules_tcp|bool
 
 - name: req-050.2 configure rules for udp
   iptables:
@@ -85,7 +85,7 @@
     ctstate: NEW
     jump: ACCEPT
   with_items: "{{ udp_services }}"
-  when: config_iptables_rules_udp
+  when: config_iptables_rules_udp|bool
 
 - name: req-050.3 configure rules for icmp (ping)
   iptables:

--- a/T-Sec.LinuxOS.Compliance/tasks/hardening_linux(05)mac.yml
+++ b/T-Sec.LinuxOS.Compliance/tasks/hardening_linux(05)mac.yml
@@ -12,7 +12,7 @@
   package:
     name: '{{ mac_software }}'
     state: present
-  when: install_mac
+  when: install_mac|bool
 
 # Req 53:	If SELinux is used, it must not be disabled in bootloader configuration.
 


### PR DESCRIPTION
This patch removes the deprecation warning

[DEPRECATION WARNING]: evaluating ????? as a bare variable, this behaviour will
go away and you might need to add |bool to the expression in the future.

Signed-off-by: Andreas Florath <andreas.florath@telekom.de>