### PR TITLE
Eliminates warning about implicit conversion to string

### DIFF
--- a/T-Sec.LinuxOS.Compliance/tasks/hardening_linux(04)iptables.yml
+++ b/T-Sec.LinuxOS.Compliance/tasks/hardening_linux(04)iptables.yml
@@ -91,7 +91,7 @@
   iptables:
     chain: INPUT
     protocol: icmp
-    icmp_type: 8
+    icmp_type: "8"
     match: state
     ctstate: NEW,ESTABLISHED,RELATED
     jump: ACCEPT


### PR DESCRIPTION
The icmp_type of the ansible's iptables module is 'string'.
The following warning was logged:
The value 8 (type int) in a string field was converted to u'8' (type string).

This patch explicitly coverts the value to a string.

Signed-off-by: Andreas Florath <andreas.florath@telekom.de>